### PR TITLE
Fallback to EDGEWEBDRIVER environment variable

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -21,7 +21,7 @@ interface ProductAPIResponse {
 }
 
 export async function download (
-  edgeVersion: string = process.env.EDGEDRIVER_VERSION,
+  edgeVersion: string = process.env.EDGEDRIVER_VERSION || process.env.EDGEWEBDRIVER,
   cacheDir: string = process.env.EDGEDRIVER_CACHE_DIR || os.tmpdir()
 ) {
   const binaryFilePath = path.resolve(cacheDir, BINARY_FILE)


### PR DESCRIPTION
Untested, but I think this may address https://github.com/webdriverio-community/node-edgedriver/issues/365#issuecomment-2263157333

https://github.com/actions/runner-images/blob/ubuntu22/20240721.1/images/ubuntu/Ubuntu2204-Readme.md#environment-variables-1 sets the EDGEWEBDRIVER environment variable