### PR TITLE
chore: update prepare script for Husky 9 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsc -b .",
     "clean": "rimraf ./node_modules package-lock.yaml ./dist",
-    "prepare": "husky install",
+    "prepare": "husky",
     "install": "test -f ./dist/install.js && node ./dist/install.js || echo \"Skipping install, project not build!\"",
     "test": "run-s test:*",
     "test:lint": "eslint",


### PR DESCRIPTION
The previous prepare script used `husky install`, which is deprecated in Husky 9. Updated to use `husky` as recommended.


This will fix the deprecation message during npm install such as the one in this recent CI:  https://github.com/webdriverio-community/node-edgedriver/actions/runs/16741724064/job/47391351732#step:5:14